### PR TITLE
feat: add pan for infinite canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                     </tr>
                     <tr>
                         <td>Erase</td>
-                        <td>Double tap and drag</td>
+                        <td>Not supported</td>
                         <td>shift + mouse drag</td>
                     </tr>
                     <tr>
@@ -114,6 +114,11 @@
                         <td>Settings</td>
                         <td>Open menu and then tap on setting</td>
                         <td>Open menu and then click on setting</td>
+                    </tr>
+                    <tr>
+                        <td>Move Canvas</td>
+                        <td>Two finger drag</td>
+                        <td>Ctrl + mouse drag</td>
                     </tr>
                     <tr>
                         <td>Undo</td>

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 Simple, standalone, flexible and very lightweight board app/PWA in JavaScript.  
   
 ## Features
+ ### v1.3.0
+ - [x] Infinite canvas with pan support (two finger drag on mobile, Ctrl + drag on desktop)
  ### v1.2.0
   - [x] Disable swipe to go back in chrome [#15](https://github.com/lablnet/board/issues/15)
 


### PR DESCRIPTION
## Summary
- support infinite canvas with offset-based pan
- allow panning with Ctrl+drag on desktop or two fingers on mobile
- document new canvas movement controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689554b1027c8332bda234365e2bb854